### PR TITLE
Fix typo

### DIFF
--- a/CameraXBasic/README.md
+++ b/CameraXBasic/README.md
@@ -11,7 +11,7 @@ To build the app directly from the command line, run:
 
 ## Test
 
-Unit testing and instrumented device testing share the same code. To test the app using Roboelectric, no device required, run:
+Unit testing and instrumented device testing share the same code. To test the app using Robolectric, no device required, run:
 ```sh
 ./gradlew test
 ```
@@ -23,6 +23,6 @@ To run the same tests in an Android device connected via ADB, run:
 
 Alternatively, test running configurations can be added to Android Studio for convenience (and a nice UI). To do that:
 1. Go to: `Run` > `Edit Configurations` > `Add New Configuration`.
-1. For Roboelectric select `Android JUnit`, for connected device select `Android Instrumented Tests`.
+1. For Robolectric select `Android JUnit`, for connected device select `Android Instrumented Tests`.
 1. Select `app` module and `com.android.example.cameraxbasic.MainInstrumentedTest` class.
-1. Optional: Give the run configuration a name, like `test roboelectric` or `test device`
+1. Optional: Give the run configuration a name, like `test robolectric` or `test device`

--- a/CameraXBasic/app/build.gradle
+++ b/CameraXBasic/app/build.gradle
@@ -54,7 +54,7 @@ android {
         }
     }
 
-    // Necessary for Roboelectric (Unit tests)
+    // Necessary for Robolectric (Unit tests)
     testOptions {
         unitTests {
             includeAndroidResources = true


### PR DESCRIPTION
`Roboelectric` -> `Robolectric`