### PR TITLE
Show Confirm AlertDialog only when photos available to delete.

### DIFF
--- a/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/GalleryFragment.kt
+++ b/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/GalleryFragment.kt
@@ -30,6 +30,7 @@ import android.content.Intent
 import android.media.MediaScannerConnection
 import android.os.Build
 import android.webkit.MimeTypeMap
+import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.FileProvider
 import com.android.example.cameraxbasic.BuildConfig
@@ -127,32 +128,37 @@ class GalleryFragment internal constructor() : Fragment() {
 
         // Handle delete button press
         view.findViewById<ImageButton>(R.id.delete_button).setOnClickListener {
-            AlertDialog.Builder(view.context, android.R.style.Theme_Material_Dialog)
-                    .setTitle(getString(R.string.delete_title))
-                    .setMessage(getString(R.string.delete_dialog))
-                    .setIcon(android.R.drawable.ic_dialog_alert)
-                    .setPositiveButton(android.R.string.yes) { _, _ ->
-                        mediaList.getOrNull(mediaViewPager.currentItem)?.let { mediaFile ->
+            if (mediaList.isNotEmpty()) {
+                AlertDialog.Builder(view.context, android.R.style.Theme_Material_Dialog)
+                        .setTitle(getString(R.string.delete_title))
+                        .setMessage(getString(R.string.delete_dialog))
+                        .setIcon(android.R.drawable.ic_dialog_alert)
+                        .setPositiveButton(android.R.string.yes) { _, _ ->
+                            mediaList.getOrNull(mediaViewPager.currentItem)?.let { mediaFile ->
 
-                            // Delete current photo
-                            mediaFile.delete()
+                                // Delete current photo
+                                mediaFile.delete()
 
-                            // Send relevant broadcast to notify other apps of deletion
-                            MediaScannerConnection.scanFile(
-                                    view.context, arrayOf(mediaFile.absolutePath), null, null)
+                                // Send relevant broadcast to notify other apps of deletion
+                                MediaScannerConnection.scanFile(
+                                        view.context, arrayOf(mediaFile.absolutePath), null, null)
 
-                            // Notify our view pager
-                            mediaList.removeAt(mediaViewPager.currentItem)
-                            mediaViewPager.adapter?.notifyDataSetChanged()
+                                // Notify our view pager
+                                mediaList.removeAt(mediaViewPager.currentItem)
+                                mediaViewPager.adapter?.notifyDataSetChanged()
 
-                            // If all photos have been deleted, return to camera
-                            if (mediaList.isEmpty()) {
-                                fragmentManager?.popBackStack()
+                                // If all photos have been deleted, return to camera
+                                if (mediaList.isEmpty()) {
+                                    fragmentManager?.popBackStack()
+                                }
                             }
-                        }}
+                        }
 
-                    .setNegativeButton(android.R.string.no, null)
-                    .create().showImmersive()
+                        .setNegativeButton(android.R.string.no, null)
+                        .create().showImmersive()
+            } else {
+                Toast.makeText(context, getString(R.string.no_photo_available), Toast.LENGTH_SHORT).show()
+            }
         }
     }
 }

--- a/CameraXBasic/app/src/main/res/values/strings.xml
+++ b/CameraXBasic/app/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="delete_button_alt">Delete</string>
     <string name="delete_dialog">Delete current photo?</string>
     <string name="delete_title">Confirm</string>
+    <string name="no_photo_available">No photo available</string>
 </resources>


### PR DESCRIPTION
Refrain from showing Confirm delete AlertDialog when no photo is available. Show a toast for the same.