### PR TITLE
Fix transformation matrix calculation and layout

### DIFF
--- a/Camera2BasicJava/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
+++ b/Camera2BasicJava/Application/src/main/java/com/example/android/camera2basic/Camera2BasicFragment.java
@@ -745,16 +745,26 @@ public class Camera2BasicFragment extends Fragment
         int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
         Matrix matrix = new Matrix();
         RectF viewRect = new RectF(0, 0, viewWidth, viewHeight);
-        RectF bufferRect = new RectF(0, 0, mPreviewSize.getHeight(), mPreviewSize.getWidth());
+        RectF bufferRect;
+        if (mSensorOrientation == 0 || mSensorOrientation == 180) {
+            bufferRect = new RectF(0, 0, mPreviewSize.getWidth(), mPreviewSize.getHeight());
+        } else {  // 90, 270
+            bufferRect = new RectF(0, 0, mPreviewSize.getHeight(), mPreviewSize.getWidth());
+        }
         float centerX = viewRect.centerX();
         float centerY = viewRect.centerY();
         if (Surface.ROTATION_90 == rotation || Surface.ROTATION_270 == rotation) {
+            // Resize the distorted rectangle in viewRect back to the dimensions of the source (bufferRect).
             bufferRect.offset(centerX - bufferRect.centerX(), centerY - bufferRect.centerY());
             matrix.setRectToRect(viewRect, bufferRect, Matrix.ScaleToFit.FILL);
+            // Scale the rectangle back so that it just covers the viewfinder.
+            float viewLongEdge = viewWidth > viewHeight ? viewWidth : viewHeight;
+            float viewShortEdge = viewWidth <= viewHeight ? viewWidth : viewHeight;
             float scale = Math.max(
-                    (float) viewHeight / mPreviewSize.getHeight(),
-                    (float) viewWidth / mPreviewSize.getWidth());
+                    (float) viewShortEdge / mPreviewSize.getHeight(),
+                    (float) viewLongEdge / mPreviewSize.getWidth());
             matrix.postScale(scale, scale, centerX, centerY);
+            // Rotate the rectangle to the correct orientation.
             matrix.postRotate(90 * (rotation - 2), centerX, centerY);
         } else if (Surface.ROTATION_180 == rotation) {
             matrix.postRotate(180, centerX, centerY);

--- a/Camera2BasicJava/Application/src/main/res/layout-land/fragment_camera2_basic.xml
+++ b/Camera2BasicJava/Application/src/main/res/layout-land/fragment_camera2_basic.xml
@@ -27,12 +27,9 @@
 
     <FrameLayout
         android:id="@+id/control"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
-        android:layout_alignParentTop="true"
-        android:layout_toRightOf="@id/texture"
         android:background="@color/control_background"
         android:orientation="horizontal">
 


### PR DESCRIPTION
The CL fixes the following issues:

- Transformation matrix calculation
When calculating transformation, we need to take sensor orientation into
consideration. The first step of the calculation tries to resize the
rectangle back to its original buffer dimensions. However it falsely
assumes that the buffer dimensions are (preview height, preview width)
(i.e., buffer is rotated by 90/270 degrees).
Another bug happens when scaling the rectangle down/up so that it just
covers the viewfinder. It falsely assumes that viewWidth is the longer
edge and viewHeight is the shorter edge. This causes the preview to be
potentially scaled up too large, leading to a "zoom-in" effect.
- Landscape layout
When texture view is able to fill most of the screen, the control layout
will be squished to a point the width becomes too small to make the
shutter button visible.

Test: Tested this on a Chromebook and Google Pixel 3