### PR TITLE
Fix orientation issues in AutoFitSurfaceView

### DIFF
--- a/Common/src/main/java/com/example/android/camera2/common/AutoFitSurfaceView.kt
+++ b/Common/src/main/java/com/example/android/camera2/common/AutoFitSurfaceView.kt
@@ -60,12 +60,13 @@ class AutoFitSurfaceView (
             // Performs center-crop transformation of the camera frames
             val newWidth: Int
             val newHeight: Int
-            if (width < height * aspectRatio) {
+            val actualRatio = if (width > height) aspectRatio else 1f / aspectRatio
+            if (width < height * actualRatio) {
                 newHeight = height
-                newWidth = (height / aspectRatio).roundToInt()
+                newWidth = (height * actualRatio).roundToInt()
             } else {
                 newWidth = width
-                newHeight = (width / aspectRatio).roundToInt()
+                newHeight = (width / actualRatio).roundToInt()
             }
 
             Log.d(TAG, "Measured dimensions set: $newWidth x $newHeight")


### PR DESCRIPTION
There are potentially multiple issues at play here. I'm not quite sure
what the original intentions were, but as far as I can see, there are 2
issues here:
- Aspect ratio isn't adjusted based on the current orientation
- Width/Height should always be the actual aspect ratio

Test: Tested on both a Chromebook and Google Pixel 3 in landscape and
portrait layout.