### PR TITLE
Changed README.md Issue links (android#148)

### DIFF
--- a/Camera2VideoJava/README.md
+++ b/Camera2VideoJava/README.md
@@ -65,7 +65,7 @@ Support
 - Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 If you've found an error in this sample, please file an issue:
-https://github.com/googlesamples/android-Camera2Video
+https://github.com/android/camera-samples/issues
 
 Patches are encouraged, and may be submitted by forking this project and
 submitting a pull request through GitHub. Please see CONTRIBUTING.md for more details.

--- a/Camera2VideoKotlin/README.md
+++ b/Camera2VideoKotlin/README.md
@@ -66,7 +66,7 @@ Support
 - Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 If you've found an error in this sample, please file an issue:
-https://github.com/googlesamples/android-Camera2Video
+https://github.com/android/camera-samples/issues
 
 Patches are encouraged, and may be submitted by forking this project and
 submitting a pull request through GitHub. Please see CONTRIBUTING.md for more details.

--- a/HdrViewfinder/README.md
+++ b/HdrViewfinder/README.md
@@ -65,7 +65,7 @@ Support
 - Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 If you've found an error in this sample, please file an issue:
-https://github.com/googlesamples/android-HdrViewfinder
+https://github.com/android/camera-samples/issues
 
 Patches are encouraged, and may be submitted by forking this project and
 submitting a pull request through GitHub. Please see CONTRIBUTING.md for more details.


### PR DESCRIPTION
Changed old Issue link in README.md: 
from 
https://github.com/googlesamples/android-Camera2Video
https://github.com/googlesamples/android-HdrViewfinder
to 
https://github.com/android/camera-samples/issues