### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ started with the [Camera APIs](https://developer.android.com/guide/topics/media/
 | [CameraXBasic](CameraXBasic)              | Demonstrates how to use CameraX APIs written in Kotlin. |
 | [Camera2Basic](Camera2Basic)              | Demostrates capturing JPEG, RAW and DEPTH images, e.g. unprocessed pixel data directly from the camera sensor. |
 | [Camera2SlowMotion](Camera2SlowMotion)    | Demostrates capturing high-speed video in a constrained camera capture session. |
-| [Camera2Video](Camera2VideoKotlin)        | Demonstrates recording video using the Camera2 API and MediaRecorder. |
+| [Camera2Video](Camera2Video)              | Demonstrates recording video using the Camera2 API and MediaRecorder. |
 | [HdrViewfinder](HdrViewfinder)            | Demonstrates use of RenderScript to display a live HDR feed from camera frames using Camera2 API. |


### PR DESCRIPTION
The README had a link that went to GitHub's 404 page. So I fixed it.