### PR TITLE
Fix aspect ratio issues with preview

### DIFF
--- a/Camera2Basic/app/src/main/res/layout-land/fragment_camera.xml
+++ b/Camera2Basic/app/src/main/res/layout-land/fragment_camera.xml
@@ -14,10 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -36,13 +34,9 @@
         android:id="@+id/capture_button"
         android:layout_width="96dp"
         android:layout_height="96dp"
-        android:layout_marginRight="96dp"
+        android:layout_gravity="center|right"
         android:scaleType="fitCenter"
         android:background="@drawable/ic_shutter"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        android:contentDescription="@string/capture"
-        tools:ignore="RtlHardcoded" />
+        android:contentDescription="@string/capture" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/Camera2Basic/app/src/main/res/layout/fragment_camera.xml
+++ b/Camera2Basic/app/src/main/res/layout/fragment_camera.xml
@@ -14,9 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -35,12 +34,9 @@
         android:id="@+id/capture_button"
         android:layout_width="96dp"
         android:layout_height="96dp"
-        android:layout_marginBottom="96dp"
+        android:layout_gravity="bottom|center"
         android:scaleType="fitCenter"
         android:background="@drawable/ic_shutter"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:contentDescription="@string/capture" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>


### PR DESCRIPTION
It seems that ConstraintLayout resizes children so that they don't clip.
This creates problems for AutoFitSurfaceView. AutoFitSurfaceView
attempts to set the measured dimension to be "just bigger" than the
viewfinder and expect that the overflowing pixels would be clipped,
creating the desired "center-crop" effect.
This commit changes the parent layout to FrameLayout.

TEST=Deployed on Pixel 4 AVD and verify the aspect ratios look right in
the test scene.