### PR TITLE
Switch YuvToRgbConverter to take in ImageProxy

### DIFF
--- a/Camera2Basic/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2Basic/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,9 +26,10 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert a [Media.Image] object from
+ * Helper class used to efficiently convert an [ImageProxy] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,7 +51,7 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var outputAllocation: Allocation
 
     @Synchronized
-    fun yuvToRgb(image: Image, output: Bitmap) {
+    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -81,7 +82,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/Camera2Basic/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2Basic/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,10 +26,9 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
-import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert an [ImageProxy] object from
+ * Helper class used to efficiently convert an [Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,8 +49,10 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var inputAllocation: Allocation
     private lateinit var outputAllocation: Allocation
 
+    // This could be changed to use ImageProxy instead. See:
+    // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
     @Synchronized
-    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
+    fun yuvToRgb(image: Image, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -82,7 +83,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/Camera2SlowMotion/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2SlowMotion/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,9 +26,10 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert a [Media.Image] object from
+ * Helper class used to efficiently convert an [ImageProxy] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,7 +51,7 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var outputAllocation: Allocation
 
     @Synchronized
-    fun yuvToRgb(image: Image, output: Bitmap) {
+    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -81,7 +82,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/Camera2SlowMotion/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2SlowMotion/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,10 +26,9 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
-import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert an [ImageProxy] object from
+ * Helper class used to efficiently convert an [Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,8 +49,10 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var inputAllocation: Allocation
     private lateinit var outputAllocation: Allocation
 
+    // This could be changed to use ImageProxy instead. See:
+    // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
     @Synchronized
-    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
+    fun yuvToRgb(image: Image, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -82,7 +83,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/Camera2Video/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2Video/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,9 +26,10 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert a [Media.Image] object from
+ * Helper class used to efficiently convert an [ImageProxy] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,7 +51,7 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var outputAllocation: Allocation
 
     @Synchronized
-    fun yuvToRgb(image: Image, output: Bitmap) {
+    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -81,7 +82,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/Camera2Video/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/Camera2Video/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,10 +26,9 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
-import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert an [ImageProxy] object from
+ * Helper class used to efficiently convert an [Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,8 +49,10 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var inputAllocation: Allocation
     private lateinit var outputAllocation: Allocation
 
+    // This could be changed to use ImageProxy instead. See:
+    // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
     @Synchronized
-    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
+    fun yuvToRgb(image: Image, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -82,7 +83,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,9 +26,10 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert a [Media.Image] object from
+ * Helper class used to efficiently convert an [ImageProxy] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,7 +51,7 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var outputAllocation: Allocation
 
     @Synchronized
-    fun yuvToRgb(image: Image, output: Bitmap) {
+    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -81,7 +82,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,10 +26,9 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
-import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert an [ImageProxy] object from
+ * Helper class used to efficiently convert an [Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,8 +49,10 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var inputAllocation: Allocation
     private lateinit var outputAllocation: Allocation
 
+    // This could be changed to use ImageProxy instead. See:
+    // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
     @Synchronized
-    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
+    fun yuvToRgb(image: Image, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -82,7 +83,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
+++ b/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
@@ -179,9 +179,9 @@ class CameraActivity : AppCompatActivity() {
                 }
 
                 // Convert the image to RGB and place it in our shared buffer
-		// You can modify YuvToRgbConverter#yuvToRgb to take image directly. This
-		// allows you to remove @SuppressLint("UnsafeExperimentalUsageError"). See:
-		// https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
+                // You can modify YuvToRgbConverter#yuvToRgb to take image directly. This
+                // allows you to remove @SuppressLint("UnsafeExperimentalUsageError"). See:
+                // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
                 image.use { converter.yuvToRgb(image.image!!, bitmapBuffer) }
 
                 // Process the image in Tensorflow

--- a/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
+++ b/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
@@ -137,7 +137,6 @@ class CameraActivity : AppCompatActivity() {
     }
 
     /** Declare and bind preview and analysis use cases */
-    @SuppressLint("UnsafeExperimentalUsageError")
     private fun bindCameraUseCases() = view_finder.post {
 
         val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
@@ -179,7 +178,7 @@ class CameraActivity : AppCompatActivity() {
                 }
 
                 // Convert the image to RGB and place it in our shared buffer
-                image.use { converter.yuvToRgb(image.image!!, bitmapBuffer) }
+                image.use { converter.yuvToRgb(image, bitmapBuffer) }
 
                 // Process the image in Tensorflow
                 val tfImage =  tfImageProcessor.process(tfImageBuffer.apply { load(bitmapBuffer) })

--- a/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
+++ b/CameraXTfLite/app/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt
@@ -137,6 +137,7 @@ class CameraActivity : AppCompatActivity() {
     }
 
     /** Declare and bind preview and analysis use cases */
+    @SuppressLint("UnsafeExperimentalUsageError")
     private fun bindCameraUseCases() = view_finder.post {
 
         val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
@@ -178,7 +179,10 @@ class CameraActivity : AppCompatActivity() {
                 }
 
                 // Convert the image to RGB and place it in our shared buffer
-                image.use { converter.yuvToRgb(image, bitmapBuffer) }
+		// You can modify YuvToRgbConverter#yuvToRgb to take image directly. This
+		// allows you to remove @SuppressLint("UnsafeExperimentalUsageError"). See:
+		// https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
+                image.use { converter.yuvToRgb(image.image!!, bitmapBuffer) }
 
                 // Process the image in Tensorflow
                 val tfImage =  tfImageProcessor.process(tfImageBuffer.apply { load(bitmapBuffer) })

--- a/CameraXTfLite/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/CameraXTfLite/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,9 +26,10 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert a [Media.Image] object from
+ * Helper class used to efficiently convert an [ImageProxy] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,7 +51,7 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var outputAllocation: Allocation
 
     @Synchronized
-    fun yuvToRgb(image: Image, output: Bitmap) {
+    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -81,7 +82,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect

--- a/CameraXTfLite/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/CameraXTfLite/utils/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -26,10 +26,9 @@ import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
-import androidx.camera.core.ImageProxy
 
 /**
- * Helper class used to efficiently convert an [ImageProxy] object from
+ * Helper class used to efficiently convert an [Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
  *
  * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
@@ -50,8 +49,10 @@ class YuvToRgbConverter(context: Context) {
     private lateinit var inputAllocation: Allocation
     private lateinit var outputAllocation: Allocation
 
+    // This could be changed to use ImageProxy instead. See:
+    // https://github.com/rogerthat94/camera-samples/commit/4364ae25dc7da500400c877a8ac5565e4cd55eec
     @Synchronized
-    fun yuvToRgb(image: ImageProxy, output: Bitmap) {
+    fun yuvToRgb(image: Image, output: Bitmap) {
 
         // Ensure that the intermediate output byte buffer is allocated
         if (!::yuvBuffer.isInitialized) {
@@ -82,7 +83,7 @@ class YuvToRgbConverter(context: Context) {
         outputAllocation.copyTo(output)
     }
 
-    private fun imageToByteArray(image: ImageProxy, outputBuffer: ByteArray) {
+    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
         assert(image.format == ImageFormat.YUV_420_888)
 
         val imageCrop = image.cropRect


### PR DESCRIPTION
Change YuvToRgbConverter to take in an ImageProxy.

This allows us to remove the `@SuppressLint("UnsafeExperimentalUsageError")` annotation from `bindCameraUseCases`.

ImageProxy is returned by CameraX. Its [documentation](https://developer.android.com/reference/androidx/camera/core/ImageProxy) notes that it "has a similar interface as Image."