### PR TITLE
Fix a known Android Q leakage reported by LeakCanary

### DIFF
--- a/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/MainActivity.kt
+++ b/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/MainActivity.kt
@@ -64,6 +64,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onBackPressed() {
+        finishAfterTransition();
+    }
+
     companion object {
 
         /** Use external media if it is available, our app's file directory otherwise */


### PR DESCRIPTION
LeakCanary reports a leakage and a buganizer issue https://b.corp.google.com/issues/178121821 was reported for it. The leakage is caused by the following reason:

Android Q added a new android.app.IRequestFinishCallback$Stub class. android.app.Activity creates an implementation of that interface as an anonymous subclass. That anonymous subclass has a reference to the activity. Another process is keeping the android.app.IRequestFinishCallback$Stub reference alive long after Activity. onDestroyed() has been called, causing the activity to leak.

The suggested solution is as the following:

Fix: You can "fix" this leak by overriding Activity. onBackPressed() and calling Activity.finishAfterTransition(); instead of super if the activity is task root and the fragment stack is empty.

Therefore, proposing this change to avoid the leakage in CameraXBasic.