### PR TITLE
Update AGP version to 4.1.3

### DIFF
--- a/Camera2Basic/build.gradle
+++ b/Camera2Basic/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '+'
+    ext.kotlin_version = '1.4.31'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,9 +26,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.2.2"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
+++ b/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 05 15:31:27 EST 2020
+#Wed Mar 31 20:44:51 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/Camera2SlowMotion/build.gradle
+++ b/Camera2SlowMotion/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '+'
+    ext.kotlin_version = '1.4.31'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,9 +26,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.2.2"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Camera2SlowMotion/gradle.properties
+++ b/Camera2SlowMotion/gradle.properties
@@ -26,4 +26,3 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true

--- a/Camera2SlowMotion/gradle/wrapper/gradle-wrapper.properties
+++ b/Camera2SlowMotion/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 05 16:15:48 EST 2020
+#Wed Mar 31 20:47:06 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/Camera2Video/build.gradle
+++ b/Camera2Video/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '+'
+    ext.kotlin_version = '1.4.31'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,9 +26,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.2.2"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Camera2Video/gradle.properties
+++ b/Camera2Video/gradle.properties
@@ -26,4 +26,3 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true

--- a/Camera2Video/gradle/wrapper/gradle-wrapper.properties
+++ b/Camera2Video/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 09 15:16:01 EDT 2020
+#Wed Mar 31 21:04:32 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/CameraUtils/build.gradle
+++ b/CameraUtils/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '+'
+    ext.kotlin_version = '1.4.31'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,7 +26,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/CameraUtils/gradle.properties
+++ b/CameraUtils/gradle.properties
@@ -9,7 +9,6 @@
 org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/CameraUtils/gradle/wrapper/gradle-wrapper.properties
+++ b/CameraUtils/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 08 10:47:51 EDT 2020
+#Wed Mar 31 21:07:00 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/CameraXBasic/build.gradle
+++ b/CameraXBasic/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '+'
+    ext.kotlin_version = '1.4.31'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,9 +26,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/CameraXTfLite/build.gradle
+++ b/CameraXTfLite/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
     ext {
         // Top-level variables used for versioning
-        ext.kotlin_version = '+'
+        ext.kotlin_version = '1.4.31'
         ext.java_version = JavaVersion.VERSION_1_8
     }
 
@@ -28,9 +28,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21'
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.27.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.1.0'
     }
 }
 
@@ -43,7 +43,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'com.diffplug.gradle.spotless'
+    apply plugin: 'com.diffplug.spotless'
     spotless {
         java {
             target "**/*.java"

--- a/HdrViewfinder/Application/build.gradle
+++ b/HdrViewfinder/Application/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 

--- a/HdrViewfinder/gradle/wrapper/gradle-wrapper.properties
+++ b/HdrViewfinder/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 06 10:29:22 EST 2020
+#Wed Mar 31 21:17:05 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
This would fix build error of
```
“Build file '/Users/gfan/tmp/camera-samples/Camera2SlowMotion/app/build.gradle' line: 18

A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'kotlin-android']
   > The current Gradle version 5.6.4 is not compatible with the Kotlin Gradle plugin. Please use Gradle 6.1 or newer, or the previous version of the Kotlin plugin.
“
```
The error only applies to Basic and SlowMotion samples, but it would be good to update the whole repo, hence this pull request.

Please take a look at it: this PR retire the usage of "+" for kotlin plugin to avoid similar failures in the future. Downside is that samples will not always use the latest kotlin plugin version.

PTAL!