### PR TITLE
More efficient and easy to understand yuv2buffer converter

### DIFF
--- a/CameraUtils/lib/src/main/java/com/example/android/camera/utils/Yuv.java
+++ b/CameraUtils/lib/src/main/java/com/example/android/camera/utils/Yuv.java
@@ -1,0 +1,317 @@
+package com.example.android.camera.utils;
+
+import android.graphics.ImageFormat;
+import android.media.Image;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.nio.ByteBuffer;
+
+
+abstract public class Yuv {
+/*
+    This file is part of https://github.com/gordinmitya/yuv2buf.
+    Follow the link to find demo app, performance benchmarks and unit tests.
+
+    Intro to YUV image formats:
+    YUV_420_888 - is a generic format that can be represented as I420, YV12, NV21, and NV12.
+    420 means that for each 4 luminosity pixels we have 2 chroma pixels: U and V.
+
+    * I420 format represents an image as Y plane followed by U then followed by V plane
+        without chroma channels interleaving.
+        For example:
+        Y Y Y Y
+        Y Y Y Y
+        U U V V
+
+    * NV21 format represents an image as Y plane followed by V and U interleaved. First V then U.
+        For example:
+        Y Y Y Y
+        Y Y Y Y
+        V U V U
+
+    * YV12 and NV12 are the same as previous formats but with swapped order of V and U. (U then V)
+
+    Visualization of these 4 formats:
+    https://user-images.githubusercontent.com/9286092/89119601-4f6f8100-d4b8-11ea-9a51-2765f7e513c2.jpg
+
+    It's guaranteed that image.getPlanes() always returns planes in order Y U V for YUV_420_888.
+    https://developer.android.com/reference/android/graphics/ImageFormat#YUV_420_888
+
+    Because I420 and NV21 are more widely supported (RenderScript, OpenCV, MNN)
+    the conversion is done into these formats.
+
+    More about each format: https://www.fourcc.org/yuv.php
+*/
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({ImageFormat.NV21, ImageFormat.YUV_420_888})
+    public @interface YuvType {
+    }
+
+    public static class Converted {
+        @YuvType
+        public final int type;
+        public final ByteBuffer buffer;
+
+        private Converted(@YuvType int type, ByteBuffer buffer) {
+            this.type = type;
+            this.buffer = buffer;
+        }
+    }
+
+    /*
+        Api.
+     */
+    @YuvType
+    public static int detectType(Image image) {
+        return detectType(wrap(image));
+    }
+
+    public static Converted toBuffer(Image image) {
+        return toBuffer(image, null);
+    }
+
+    public static Converted toBuffer(Image image, ByteBuffer reuse) {
+        return toBuffer(wrap(image), reuse);
+    }
+
+    private static ImageWrapper wrap(Image image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        Image.Plane[] planes = image.getPlanes();
+        PlaneWrapper y = wrap(width, height, planes[0]);
+        PlaneWrapper u = wrap(width / 2, height / 2, planes[1]);
+        PlaneWrapper v = wrap(width / 2, height / 2, planes[2]);
+        return new ImageWrapper(width, height, y, u, v);
+    }
+
+    private static PlaneWrapper wrap(int width, int height, Image.Plane plane) {
+        return new PlaneWrapper(
+            width,
+            height,
+            plane.getBuffer(),
+            plane.getRowStride(),
+            plane.getPixelStride()
+        );
+    }
+
+    /*
+        CameraX api. If you don't need it – just comment lines below.
+     */
+    /*
+    @YuvType
+    public static int detectType(ImageProxy image) {
+        return detectType(wrap(image));
+    }
+
+    public static Converted toBuffer(ImageProxy image) {
+        return toBuffer(image, null);
+    }
+
+    public static Converted toBuffer(ImageProxy image, ByteBuffer reuse) {
+        return toBuffer(wrap(image), reuse);
+    }
+
+    private static ImageWrapper wrap(ImageProxy image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+        ImageProxy.PlaneProxy[] planes = image.getPlanes();
+        PlaneWrapper y = wrap(width, height, planes[0]);
+        PlaneWrapper u = wrap(width / 2, height / 2, planes[1]);
+        PlaneWrapper v = wrap(width / 2, height / 2, planes[2]);
+        return new ImageWrapper(width, height, y, u, v);
+    }
+
+    private static PlaneWrapper wrap(int width, int height, ImageProxy.PlaneProxy plane) {
+        return new PlaneWrapper(
+            width,
+            height,
+            plane.getBuffer(),
+            plane.getRowStride(),
+            plane.getPixelStride()
+        );
+    }
+    */
+    // End of CameraX api.
+
+    /*
+        Implementation
+     */
+
+    /*
+     other pixelStride are not possible
+     @see #ImageWrapper.checkFormat()
+     */
+    @YuvType
+    static int detectType(ImageWrapper image) {
+        if (image.u.pixelStride == 1) {
+            return ImageFormat.YUV_420_888;
+        } else {
+            return ImageFormat.NV21;
+        }
+    }
+
+    static Converted toBuffer(ImageWrapper image, ByteBuffer reuse) {
+        final int type = detectType(image);
+        ByteBuffer output = prepareOutput(image, reuse);
+        removePadding(image, type, output);
+        return new Converted(type, output);
+    }
+
+    private static ByteBuffer prepareOutput(ImageWrapper image, ByteBuffer reuse) {
+        int sizeOutput = image.width * image.height * 3 / 2;
+        ByteBuffer output;
+        if (reuse == null
+            || reuse.capacity() < sizeOutput
+            || reuse.isReadOnly()
+            || !reuse.isDirect()) {
+            output = ByteBuffer.allocateDirect(sizeOutput);
+        } else {
+            output = reuse;
+        }
+        output.rewind();
+        return output;
+    }
+
+    // Input buffers are always direct as described in
+    // https://developer.android.com/reference/android/media/Image.Plane#getBuffer()
+    private static void removePadding(
+        ImageWrapper image,
+        @YuvType final int type,
+        ByteBuffer output
+    ) {
+        int sizeLuma = image.y.width * image.y.height;
+        int sizeChroma = image.u.width * image.u.height;
+
+        if (image.y.rowStride > image.y.width) {
+            removePaddingCompact(image.y, output, 0);
+        } else {
+            output.position(0);
+            output.put(image.y.buffer);
+        }
+
+        if (type == ImageFormat.YUV_420_888) {
+            if (image.u.rowStride > image.u.width) {
+                removePaddingCompact(image.u, output, sizeLuma);
+                removePaddingCompact(image.v, output, sizeLuma + sizeChroma);
+            } else {
+                output.position(sizeLuma);
+                output.put(image.u.buffer);
+                output.position(sizeLuma + sizeChroma);
+                output.put(image.v.buffer);
+            }
+        } else {
+            if (image.u.rowStride > image.u.width * 2) {
+                removePaddingNotCompact(image, output, sizeLuma);
+            } else {
+                output.position(sizeLuma);
+                ByteBuffer uv = image.v.buffer;
+                final int properUVSize = image.v.height * image.v.rowStride - 1;
+                if (uv.capacity() > properUVSize) {
+                    uv = clipBuffer(image.v.buffer, 0, properUVSize);
+                }
+                output.put(uv);
+                final byte lastOne = image.u.buffer.get(image.u.buffer.capacity() - 1);
+                output.put(output.capacity() - 1, lastOne);
+            }
+        }
+        output.rewind();
+    }
+
+    private static void removePaddingCompact(PlaneWrapper plane, ByteBuffer dst, int offset) {
+        if (plane.pixelStride != 1) {
+            throw new IllegalArgumentException("use removePaddingCompact with pixelStride == 1");
+        }
+
+        ByteBuffer src = plane.buffer;
+        int rowStride = plane.rowStride;
+        ByteBuffer row;
+        dst.position(offset);
+        for (int i = 0; i < plane.height; i++) {
+            row = clipBuffer(src, i * rowStride, plane.width);
+            dst.put(row);
+        }
+    }
+
+    private static void removePaddingNotCompact(ImageWrapper image, ByteBuffer dst, int offset) {
+        if (image.u.pixelStride != 2) {
+            throw new IllegalArgumentException("use removePaddingNotCompact pixelStride == 2");
+        }
+
+        int width = image.u.width;
+        int height = image.u.height;
+        int rowStride = image.u.rowStride;
+        ByteBuffer row;
+        dst.position(offset);
+        for (int i = 0; i < height - 1; i++) {
+            row = clipBuffer(image.v.buffer, i * rowStride, width * 2);
+            dst.put(row);
+        }
+        row = clipBuffer(image.u.buffer, (height - 1) * rowStride - 1, width * 2);
+        dst.put(row);
+    }
+
+    private static ByteBuffer clipBuffer(ByteBuffer buffer, int start, int size) {
+        ByteBuffer duplicate = buffer.duplicate();
+        duplicate.position(start);
+        duplicate.limit(start + size);
+        return duplicate.slice();
+    }
+
+    static class ImageWrapper {
+        final int width, height;
+        final PlaneWrapper y, u, v;
+
+        ImageWrapper(int width, int height, PlaneWrapper y, PlaneWrapper u, PlaneWrapper v) {
+            this.width = width;
+            this.height = height;
+            this.y = y;
+            this.u = u;
+            this.v = v;
+            checkFormat();
+        }
+
+
+        // Check this is a supported image format
+        // https://developer.android.com/reference/android/graphics/ImageFormat#YUV_420_888
+        private void checkFormat() {
+            if (y.pixelStride != 1) {
+                throw new IllegalArgumentException(String.format(
+                    "Pixel stride for Y plane must be 1 but got %d instead",
+                    y.pixelStride
+                ));
+            }
+            if (u.pixelStride != v.pixelStride || u.rowStride != v.rowStride) {
+                throw new IllegalArgumentException(String.format(
+                    "U and V planes must have the same pixel and row strides " +
+                        "but got pixel=%d row=%d for U " +
+                        "and pixel=%d and row=%d for V",
+                    u.pixelStride, u.rowStride,
+                    v.pixelStride, v.rowStride
+                ));
+            }
+            if (u.pixelStride != 1 && u.pixelStride != 2) {
+                throw new IllegalArgumentException(
+                    "Supported pixel strides for U and V planes are 1 and 2"
+                );
+            }
+        }
+    }
+
+    static class PlaneWrapper {
+        final int width, height;
+        final ByteBuffer buffer;
+        final int rowStride, pixelStride;
+
+        PlaneWrapper(int width, int height, ByteBuffer buffer, int rowStride, int pixelStride) {
+            this.width = width;
+            this.height = height;
+            this.buffer = buffer;
+            this.rowStride = rowStride;
+            this.pixelStride = pixelStride;
+        }
+    }
+}

--- a/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
+++ b/CameraUtils/lib/src/main/java/com/example/android/camera/utils/YuvToRgbConverter.kt
@@ -19,180 +19,58 @@ package com.example.android.camera.utils
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.ImageFormat
-import android.graphics.Rect
 import android.media.Image
 import android.renderscript.Allocation
 import android.renderscript.Element
 import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicYuvToRGB
 import android.renderscript.Type
+import java.nio.ByteBuffer
 
 /**
  * Helper class used to efficiently convert a [Media.Image] object from
  * [ImageFormat.YUV_420_888] format to an RGB [Bitmap] object.
- *
- * The [yuvToRgb] method is able to achieve the same FPS as the CameraX image
- * analysis use case on a Pixel 3 XL device at the default analyzer resolution,
- * which is 30 FPS with 640x480.
- *
- * NOTE: This has been tested in a limited number of devices and is not
- * considered production-ready code. It was created for illustration purposes,
- * since this is not an efficient camera pipeline due to the multiple copies
- * required to convert each frame.
  */
 class YuvToRgbConverter(context: Context) {
     private val rs = RenderScript.create(context)
     private val scriptYuvToRgb = ScriptIntrinsicYuvToRGB.create(rs, Element.U8_4(rs))
 
-    private var pixelCount: Int = -1
-    private lateinit var yuvBuffer: ByteArray
-    private lateinit var inputAllocation: Allocation
-    private lateinit var outputAllocation: Allocation
+    private var reuseBuffer: ByteBuffer? = null
+    private var bytes: ByteArray = ByteArray(0)
+    private var inputAllocation: Allocation? = null
+    private var outputAllocation: Allocation? = null
 
+    // for CameraX pass ImageProxy
     @Synchronized
     fun yuvToRgb(image: Image, output: Bitmap) {
+        val converted = Yuv.toBuffer(image, reuseBuffer)
+        reuseBuffer = converted.buffer
 
-        // Ensure that the intermediate output byte buffer is allocated
-        if (!::yuvBuffer.isInitialized) {
-            pixelCount = image.cropRect.width() * image.cropRect.height()
-            // Bits per pixel is an average for the whole image, so it's useful to compute the size
-            // of the full buffer but should not be used to determine pixel offsets
-            val pixelSizeBits = ImageFormat.getBitsPerPixel(ImageFormat.YUV_420_888)
-            yuvBuffer = ByteArray(pixelCount * pixelSizeBits / 8)
+        if (inputAllocation == null
+            || inputAllocation!!.type.x != image.width
+            || inputAllocation!!.type.y != image.height
+            || inputAllocation!!.type.yuv != converted.type
+            || bytes.size != converted.buffer.capacity()
+        ) {
+            val yuvType: Type.Builder = Type.Builder(rs, Element.U8(rs))
+                .setX(image.width)
+                .setY(image.height)
+                .setYuvFormat(converted.type)
+            inputAllocation = Allocation.createTyped(rs, yuvType.create(), Allocation.USAGE_SCRIPT)
+            bytes = ByteArray(converted.buffer.capacity())
+            val rgbaType: Type.Builder = Type.Builder(rs, Element.RGBA_8888(rs))
+                .setX(image.width)
+                .setY(image.height)
+            outputAllocation = Allocation.createTyped(rs, rgbaType.create(), Allocation.USAGE_SCRIPT)
         }
 
-        // Get the YUV data in byte array form using NV21 format
-        imageToByteArray(image, yuvBuffer)
+        converted.buffer.get(bytes)
+        inputAllocation!!.copyFrom(bytes)
 
-        // Ensure that the RenderScript inputs and outputs are allocated
-        if (!::inputAllocation.isInitialized) {
-            // Explicitly create an element with type NV21, since that's the pixel format we use
-            val elemType = Type.Builder(rs, Element.YUV(rs)).setYuvFormat(ImageFormat.NV21).create()
-            inputAllocation = Allocation.createSized(rs, elemType.element, yuvBuffer.size)
-        }
-        if (!::outputAllocation.isInitialized) {
-            outputAllocation = Allocation.createFromBitmap(rs, output)
-        }
-
-        // Convert NV21 format YUV to RGB
-        inputAllocation.copyFrom(yuvBuffer)
+        // Convert NV21 or YUV_420_888 format to RGB
+        inputAllocation!!.copyFrom(bytes)
         scriptYuvToRgb.setInput(inputAllocation)
         scriptYuvToRgb.forEach(outputAllocation)
-        outputAllocation.copyTo(output)
-    }
-
-    private fun imageToByteArray(image: Image, outputBuffer: ByteArray) {
-        assert(image.format == ImageFormat.YUV_420_888)
-
-        val imageCrop = image.cropRect
-        val imagePlanes = image.planes
-
-        imagePlanes.forEachIndexed { planeIndex, plane ->
-            // How many values are read in input for each output value written
-            // Only the Y plane has a value for every pixel, U and V have half the resolution i.e.
-            //
-            // Y Plane            U Plane    V Plane
-            // ===============    =======    =======
-            // Y Y Y Y Y Y Y Y    U U U U    V V V V
-            // Y Y Y Y Y Y Y Y    U U U U    V V V V
-            // Y Y Y Y Y Y Y Y    U U U U    V V V V
-            // Y Y Y Y Y Y Y Y    U U U U    V V V V
-            // Y Y Y Y Y Y Y Y
-            // Y Y Y Y Y Y Y Y
-            // Y Y Y Y Y Y Y Y
-            val outputStride: Int
-
-            // The index in the output buffer the next value will be written at
-            // For Y it's zero, for U and V we start at the end of Y and interleave them i.e.
-            //
-            // First chunk        Second chunk
-            // ===============    ===============
-            // Y Y Y Y Y Y Y Y    V U V U V U V U
-            // Y Y Y Y Y Y Y Y    V U V U V U V U
-            // Y Y Y Y Y Y Y Y    V U V U V U V U
-            // Y Y Y Y Y Y Y Y    V U V U V U V U
-            // Y Y Y Y Y Y Y Y
-            // Y Y Y Y Y Y Y Y
-            // Y Y Y Y Y Y Y Y
-            var outputOffset: Int
-
-            when (planeIndex) {
-                0 -> {
-                    outputStride = 1
-                    outputOffset = 0
-                }
-                1 -> {
-                    outputStride = 2
-                    // For NV21 format, U is in odd-numbered indices
-                    outputOffset = pixelCount + 1
-                }
-                2 -> {
-                    outputStride = 2
-                    // For NV21 format, V is in even-numbered indices
-                    outputOffset = pixelCount
-                }
-                else -> {
-                    // Image contains more than 3 planes, something strange is going on
-                    return@forEachIndexed
-                }
-            }
-
-            val planeBuffer = plane.buffer
-            val rowStride = plane.rowStride
-            val pixelStride = plane.pixelStride
-
-            // We have to divide the width and height by two if it's not the Y plane
-            val planeCrop = if (planeIndex == 0) {
-                imageCrop
-            } else {
-                Rect(
-                    imageCrop.left / 2,
-                    imageCrop.top / 2,
-                    imageCrop.right / 2,
-                    imageCrop.bottom / 2
-                )
-            }
-
-            val planeWidth = planeCrop.width()
-            val planeHeight = planeCrop.height()
-
-            // Intermediate buffer used to store the bytes of each row
-            val rowBuffer = ByteArray(plane.rowStride)
-
-            // Size of each row in bytes
-            val rowLength = if (pixelStride == 1 && outputStride == 1) {
-                planeWidth
-            } else {
-                // Take into account that the stride may include data from pixels other than this
-                // particular plane and row, and that could be between pixels and not after every
-                // pixel:
-                //
-                // |---- Pixel stride ----|                    Row ends here --> |
-                // | Pixel 1 | Other Data | Pixel 2 | Other Data | ... | Pixel N |
-                //
-                // We need to get (N-1) * (pixel stride bytes) per row + 1 byte for the last pixel
-                (planeWidth - 1) * pixelStride + 1
-            }
-
-            for (row in 0 until planeHeight) {
-                // Move buffer position to the beginning of this row
-                planeBuffer.position(
-                    (row + planeCrop.top) * rowStride + planeCrop.left * pixelStride)
-
-                if (pixelStride == 1 && outputStride == 1) {
-                    // When there is a single stride value for pixel and output, we can just copy
-                    // the entire row in a single step
-                    planeBuffer.get(outputBuffer, outputOffset, rowLength)
-                    outputOffset += rowLength
-                } else {
-                    // When either pixel or output have a stride > 1 we must copy pixel by pixel
-                    planeBuffer.get(rowBuffer, 0, rowLength)
-                    for (col in 0 until planeWidth) {
-                        outputBuffer[outputOffset] = rowBuffer[col * pixelStride]
-                        outputOffset += outputStride
-                    }
-                }
-            }
-        }
+        outputAllocation!!.copyTo(output)
     }
 }


### PR DESCRIPTION
Sorry, I unintentionally closed https://github.com/android/camera-samples/pull/336, so here is updated version of it.

Part discussion of this code is in issue #277.
Documentation about approach, unit-tests, performance benchmarks + demo application are here https://github.com/gordinmitya/yuv2buf. This code is tested in several apps in production with both: Camera2 output and MediaCodec outputs.

I compared performance of previous and new code on my Mi 9t pro (Snapdragon 855): old 3.5-4.0ms, new 2.6-3.0ms.
Modified CameraActivity.kt was used for comparison.

Will be happy to answer questions, if any!