### PR TITLE
Update to CameraX's RGB output (released in core lib 1.1.0-alpha09)

### DIFF
--- a/CameraXTfLite/README.md
+++ b/CameraXTfLite/README.md
@@ -3,10 +3,11 @@ This sample implements an Activity that performs real-time object detection on
 the live camera frames. It performs the following operations:
 1. Initializes camera preview and image analysis frame streams using CameraX
 2. Loads a mobilenet quantized model using Tensorflow Lite
-3. Converts each incoming frame to the RGB colorspace and resizes it to 224x224 pixels
 4. Performs inference on the transformed frames and reports the object predicted on the screen
 
-The whole pipeline is able to maintain 30 FPS on a Pixel 3 XL.
+The whole pipeline is able to maintain 30 FPS on a Pixel 3 XL with:
+- the default image size from Camera (640x480)
+- the default tensor size (300 x 300)
 
 ## Screenshots
 ![demo](screenshots/demo.gif "demo animation")

--- a/CameraXTfLite/app/build.gradle
+++ b/CameraXTfLite/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "21.3.6528147"
 
     defaultConfig {
@@ -49,7 +49,6 @@ android {
 }
 
 dependencies {
-    implementation project(':utils')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     // App compat and UI things
@@ -58,13 +57,13 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     // CameraX
-    def camerax_version = "1.1.0-alpha07"
+    def camerax_version = "1.1.0-alpha09"
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"
 
     // CameraX View class
-    implementation "androidx.camera:camera-view:1.0.0-alpha27"
+    implementation "androidx.camera:camera-view:1.0.0-alpha29"
 
     // Tensorflow lite dependencies
     implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly-SNAPSHOT'

--- a/CameraXTfLite/settings.gradle
+++ b/CameraXTfLite/settings.gradle
@@ -1,2 +1,1 @@
 include 'app'
-include 'utils'


### PR DESCRIPTION
Update CameraXTflite sample with [RGBA output](https://developer.android.com/training/camerax/analyze)(removing dependency on the renderscript).
Observed the following known issue, following up with TFLite team in a separate thread :
```
com.android.example.camerax.tflite E/.camerax.tflit: NN_RET_CHECK failed (frameworks/ml/nn/common/operations/Concatenation.cpp:162): input.scale == output.scale (input.scale = 0.0482365, output.scale = 0.0497368) 
com.android.example.camerax.tflite E/Utils: Validation failed for operation CONCATENATION
```
This has been there in the sample, not new to this code change. It is related to the model, not the  image data input. So it is safe to merge.