### PR TITLE
Media store needs external storage access for Android 9 and bellow.

### DIFF
--- a/CameraXVideo/app/src/main/AndroidManifest.xml
+++ b/CameraXVideo/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <!-- Permission declarations -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <!-- A camera with burst capability is required to use this application -->
     <uses-feature android:name="android.hardware.camera.any" />

--- a/CameraXVideo/app/src/main/java/com/example/android/camerax/video/fragments/CameraFragment.kt
+++ b/CameraXVideo/app/src/main/java/com/example/android/camerax/video/fragments/CameraFragment.kt
@@ -395,11 +395,14 @@ class CameraFragment : Fragment() {
                 fragmentCameraBinding.qualitySelection).forEach {
                     it.isEnabled = enable
         }
-        // fixup for qualitySelector list
+        // disable the camera button if no device to switch
         if (cameraCapabilities.size <= 1) {
-            fragmentCameraBinding.qualitySelection.let {
-                it.visibility = View.INVISIBLE
-                it.isEnabled = false
+            fragmentCameraBinding.cameraButton.isEnabled = false
+        }
+        // disable the resolution list if no resolution to switch
+        if (cameraCapabilities[cameraIndex].qualitySelector.size <= 1) {
+            fragmentCameraBinding.qualitySelection.apply {
+                isEnabled = false
             }
         }
     }

--- a/CameraXVideo/app/src/main/java/com/example/android/camerax/video/fragments/PermissionsFragment.kt
+++ b/CameraXVideo/app/src/main/java/com/example/android/camerax/video/fragments/PermissionsFragment.kt
@@ -19,6 +19,7 @@ package com.example.android.camerax.video.fragments
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -32,7 +33,7 @@ import androidx.navigation.Navigation
 import com.example.android.camerax.video.R
 import com.example.android.camerax.video.databinding.FragmentPermissionBinding
 
-private val PERMISSIONS_REQUIRED = arrayOf(
+private var PERMISSIONS_REQUIRED = arrayOf(
     Manifest.permission.CAMERA,
     Manifest.permission.RECORD_AUDIO)
 
@@ -42,6 +43,13 @@ private val PERMISSIONS_REQUIRED = arrayOf(
 class PermissionsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // add the storage access permission request for Android 9 and below.
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            val permissionList = PERMISSIONS_REQUIRED.toMutableList()
+            permissionList.add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            PERMISSIONS_REQUIRED = permissionList.toTypedArray()
+        }
 
         if (!hasPermissions(requireContext())) {
             // Request camera-related permissions


### PR DESCRIPTION
Tested on Pixel (android 9) and Pixel 3a (android 11)
