### PR TITLE
Remove current CameraState observers when cameras are switched

### DIFF
--- a/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/CameraFragment.kt
+++ b/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/CameraFragment.kt
@@ -321,6 +321,11 @@ class CameraFragment : Fragment() {
         // Must unbind the use-cases before rebinding them
         cameraProvider.unbindAll()
 
+        if (camera != null) {
+            // Must remove observers from the previous camera instance
+            removeCameraStateObservers(camera!!.cameraInfo)
+        }
+
         try {
             // A variable number of use-cases can be passed here -
             // camera provides access to CameraControl & CameraInfo
@@ -333,6 +338,10 @@ class CameraFragment : Fragment() {
         } catch (exc: Exception) {
             Log.e(TAG, "Use case binding failed", exc)
         }
+    }
+
+    private fun removeCameraStateObservers(cameraInfo: CameraInfo) {
+        cameraInfo.cameraState.removeObservers(viewLifecycleOwner)
     }
 
     private fun observeCameraState(cameraInfo: CameraInfo) {


### PR DESCRIPTION
On every camera switch, an additional `CameraState` observer was created and added to the list of `CameraState` observers. As a result, every change of `CameraState` was handled multiple times.

**Steps to reproduce:**
1. Switch cameras multiple times
2. Toast message starts displaying duplicate messages as multiple callbacks are triggered

**Fix:**
Remove existing observers after every camera switch.
_Another solution might be to keep a reference to the one existing observer._