### PR TITLE
Camerax viewstate

### DIFF
--- a/CameraXExtensions/app/build.gradle
+++ b/CameraXExtensions/app/build.gradle
@@ -27,16 +27,24 @@ kapt {
 
 android {
     namespace 'com.example.android.cameraxextensions'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.example.android.cameraxextensions"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.3.2"
     }
 
     buildTypes {
@@ -54,11 +62,12 @@ android {
     kotlinOptions {
         jvmTarget = rootProject.ext.java_version
     }
+
 }
 
 dependencies {
     // Kotlin lang
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
 
     // CameraX
     implementation "androidx.camera:camera-core:$camerax_version"
@@ -81,11 +90,20 @@ dependencies {
     // Image loading
     implementation "io.coil-kt:coil:2.1.0"
 
-    implementation 'androidx.activity:activity-ktx:1.5.1'
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    // Compose
+    implementation 'androidx.compose.material:material:1.2.1'
+    implementation 'androidx.compose.ui:ui:1.2.1'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.2.1'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.2.1'
+    implementation 'androidx.activity:activity-compose:1.6.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
+
+    implementation 'androidx.activity:activity-ktx:1.6.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "androidx.recyclerview:recyclerview:1.2.1"
+
 
     // Test
     testImplementation 'junit:junit:4.13.2'

--- a/CameraXExtensions/app/src/main/AndroidManifest.xml
+++ b/CameraXExtensions/app/src/main/AndroidManifest.xml
@@ -39,6 +39,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+       <!-- FileProvider used to share photos with other apps -->
+       <provider
+           android:name="androidx.core.content.FileProvider"
+           android:authorities="${applicationId}.provider"
+           android:exported="false"
+           android:grantUriPermissions="true">
+           <meta-data
+               android:name="android.support.FILE_PROVIDER_PATHS"
+               android:resource="@xml/file_paths"/>
+       </provider>
+
     </application>
 
 </manifest>

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
@@ -148,6 +148,9 @@ class MainActivity : AppCompatActivity() {
                     is CameraUiAction.Focus -> {
                         cameraExtensionsViewModel.focus(action.meteringPoint)
                     }
+                    is CameraUiAction.Scale -> {
+                        cameraExtensionsViewModel.scale(action.scaleFactor)
+                    }
                 }
             }
         }

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
@@ -145,6 +145,9 @@ class MainActivity : AppCompatActivity() {
                     CameraUiAction.RequestPermissionClick -> {
                         requestPermissionsLauncher.launch(Manifest.permission.CAMERA)
                     }
+                    is CameraUiAction.Focus -> {
+                        cameraExtensionsViewModel.focus(action.meteringPoint)
+                    }
                 }
             }
         }

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/MainActivity.kt
@@ -20,22 +20,20 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.extensions.ExtensionMode
 import androidx.core.app.ActivityCompat
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.*
 import com.example.android.cameraxextensions.adapter.CameraExtensionItem
 import com.example.android.cameraxextensions.model.CameraState
 import com.example.android.cameraxextensions.model.CameraUiAction
 import com.example.android.cameraxextensions.model.CaptureState
 import com.example.android.cameraxextensions.model.PermissionState
+import com.example.android.cameraxextensions.repository.ImageCaptureRepository
 import com.example.android.cameraxextensions.ui.CameraExtensionsScreen
 import com.example.android.cameraxextensions.ui.doOnLaidOut
 import com.example.android.cameraxextensions.viewmodel.CameraExtensionsViewModel
+import com.example.android.cameraxextensions.viewmodel.CameraExtensionsViewModelFactory
 import com.example.android.cameraxextensions.viewstate.CaptureScreenViewState
 import com.example.android.cameraxextensions.viewstate.PostCaptureScreenViewState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,7 +56,7 @@ class MainActivity : AppCompatActivity() {
     )
 
     // view model for operating on the camera and capturing a photo
-    private val cameraExtensionsViewModel: CameraExtensionsViewModel by viewModels()
+    private lateinit var cameraExtensionsViewModel: CameraExtensionsViewModel
 
     // monitors changes in camera permission state
     private lateinit var permissionState: MutableStateFlow<PermissionState>
@@ -67,6 +65,14 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_main)
+
+        cameraExtensionsViewModel = ViewModelProvider(
+            this,
+            CameraExtensionsViewModelFactory(
+                application,
+                ImageCaptureRepository.create(applicationContext)
+            )
+        )[CameraExtensionsViewModel::class.java]
 
         // capture screen abstracts the UI logic and exposes simple functions on how to interact
         // with the UI layer.

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiAction.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiAction.kt
@@ -16,6 +16,7 @@
 
 package com.example.android.cameraxextensions.model
 
+import androidx.camera.core.MeteringPoint
 import androidx.camera.extensions.ExtensionMode
 
 /**
@@ -27,4 +28,5 @@ sealed class CameraUiAction {
     object ShutterButtonClick : CameraUiAction()
     object ClosePhotoPreviewClick : CameraUiAction()
     data class SelectCameraExtension(@ExtensionMode.Mode val extension: Int) : CameraUiAction()
+    data class Focus(val meteringPoint: MeteringPoint) : CameraUiAction()
 }

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiAction.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiAction.kt
@@ -29,4 +29,5 @@ sealed class CameraUiAction {
     object ClosePhotoPreviewClick : CameraUiAction()
     data class SelectCameraExtension(@ExtensionMode.Mode val extension: Int) : CameraUiAction()
     data class Focus(val meteringPoint: MeteringPoint) : CameraUiAction()
+    data class Scale(val scaleFactor: Float) : CameraUiAction()
 }

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/repository/ImageCaptureRepository.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/repository/ImageCaptureRepository.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.repository
+
+import android.content.Context
+import android.content.Intent
+import android.hardware.Camera.ACTION_NEW_PICTURE
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import androidx.core.net.toFile
+import com.example.android.cameraxextensions.R
+import java.io.File
+import java.util.*
+
+/**
+ * Manages photo capture filename and location generation. Once a photo is captured and saved to
+ * disk, the repository will also notify that the image has been created such that other
+ * applications can view it.
+ */
+class ImageCaptureRepository internal constructor(private val rootDirectory: File) {
+    companion object {
+        const val TAG = "ImageCaptureRepository"
+
+        private const val PHOTO_EXTENSION = ".jpg"
+
+        fun create(context: Context): ImageCaptureRepository {
+            // Use external media if it is available and this app's file directory otherwise
+            val appContext = context.applicationContext
+            val mediaDir = context.externalMediaDirs.firstOrNull()?.let {
+                File(it, appContext.resources.getString(R.string.app_name)).apply { mkdirs() }
+            }
+            val file = if (mediaDir?.exists() == true) mediaDir else appContext.filesDir
+            return ImageCaptureRepository(file)
+        }
+    }
+
+    fun notifyImageCreated(context: Context, savedUri: Uri) {
+        val file = savedUri.toFile()
+        val fileProviderUri =
+            FileProvider.getUriForFile(context, context.packageName + ".provider", file)
+        context.sendBroadcast(
+            Intent(ACTION_NEW_PICTURE, fileProviderUri)
+        )
+
+        // Notify other apps so they can access the captured image
+        val mimeType = MimeTypeMap.getSingleton()
+            .getMimeTypeFromExtension(file.extension)
+
+        MediaScannerConnection.scanFile(
+            context,
+            arrayOf(file.absolutePath),
+            arrayOf(mimeType),
+        ) { _, _ -> }
+    }
+
+    fun createImageOutputFile(): File = File(rootDirectory, generateFilename(PHOTO_EXTENSION))
+
+    private fun generateFilename(extension: String): String =
+        UUID.randomUUID().toString() + extension
+}

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/ui/CameraExtensionsScreen.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/ui/CameraExtensionsScreen.kt
@@ -32,9 +32,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.example.android.cameraxextensions.R
-import com.example.android.cameraxextensions.adapter.CameraExtensionItem
 import com.example.android.cameraxextensions.adapter.CameraExtensionsSelectorAdapter
 import com.example.android.cameraxextensions.model.CameraUiAction
+import com.example.android.cameraxextensions.viewstate.CameraPreviewScreenViewState
+import com.example.android.cameraxextensions.viewstate.CaptureScreenViewState
+import com.example.android.cameraxextensions.viewstate.PostCaptureScreenViewState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -143,40 +145,12 @@ class CameraExtensionsScreen(private val root: View) {
         }
     }
 
-    fun setAvailableExtensions(extensions: List<CameraExtensionItem>) {
-        extensionsAdapter.submitList(extensions)
-    }
-
-    fun showPhoto(uri: Uri?) {
-        if (uri == null) return
-        photoPreview.isVisible = true
-        photoPreview.load(uri)
-        closePhotoPreview.isVisible = true
-    }
-
-    fun hidePhoto() {
-        photoPreview.isVisible = false
-        closePhotoPreview.isVisible = false
-        extensionSelector.isVisible = false
-    }
-
-    fun showCameraControls() {
-        cameraShutterButton.isVisible = true
-        switchLensButton.isVisible = true
-        extensionSelector.isVisible = true
-    }
-
-    fun hideCameraControls() {
-        cameraShutterButton.isVisible = false
-        switchLensButton.isVisible = false
-    }
-
-    fun enableCameraShutter(isEnabled: Boolean) {
-        cameraShutterButton.isEnabled = isEnabled
-    }
-
-    fun enableSwitchLens(isEnabled: Boolean) {
-        switchLensButton.isEnabled = isEnabled
+    fun setCaptureScreenViewState(state: CaptureScreenViewState) {
+        setCameraScreenViewState(state.cameraPreviewScreenViewState)
+        when (state.postCaptureScreenViewState) {
+            PostCaptureScreenViewState.PostCaptureScreenHiddenViewState -> hidePhoto()
+            is PostCaptureScreenViewState.PostCaptureScreenVisibleViewState -> showPhoto(state.postCaptureScreenViewState.uri)
+        }
     }
 
     fun showCaptureError(errorMessage: String) {
@@ -195,6 +169,29 @@ class CameraExtensionsScreen(private val root: View) {
         } else {
             permissionsRationale.text = context.getString(R.string.camera_permissions_request)
         }
+    }
+
+    private fun showPhoto(uri: Uri?) {
+        if (uri == null) return
+        photoPreview.isVisible = true
+        photoPreview.load(uri)
+        closePhotoPreview.isVisible = true
+    }
+
+    private fun hidePhoto() {
+        photoPreview.isVisible = false
+        closePhotoPreview.isVisible = false
+    }
+
+    private fun setCameraScreenViewState(state: CameraPreviewScreenViewState) {
+        cameraShutterButton.isEnabled = state.shutterButtonViewState.isEnabled
+        cameraShutterButton.isVisible = state.shutterButtonViewState.isVisible
+
+        switchLensButton.isEnabled = state.switchLensButtonViewState.isEnabled
+        switchLensButton.isVisible = state.switchLensButtonViewState.isVisible
+
+        extensionSelector.isVisible = state.extensionsSelectorViewState.isVisible
+        extensionsAdapter.submitList(state.extensionsSelectorViewState.extensions)
     }
 
     private fun onItemClick(view: View) {

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/ui/FocusPointDrawable.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/ui/FocusPointDrawable.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.ui
+
+import android.graphics.*
+import android.graphics.drawable.Drawable
+import kotlin.math.min
+
+class FocusPointDrawable : Drawable() {
+    private val paint = Paint().apply {
+        isAntiAlias = true
+        style = Paint.Style.STROKE
+        color = Color.WHITE
+    }
+
+    private var radius: Float = 0f
+    private var centerX: Float = 0f
+    private var centerY: Float = 0f
+
+    fun setStrokeWidth(strokeWidth: Float): Boolean =
+        if (paint.strokeWidth == strokeWidth) {
+            false
+        } else {
+            paint.strokeWidth = strokeWidth
+            true
+        }
+
+    override fun onBoundsChange(bounds: Rect) {
+        val width = bounds.width()
+        val height = bounds.height()
+        radius = min(width, height) / 2f - paint.strokeWidth / 2f
+        centerX = width / 2f
+        centerY = height / 2f
+    }
+
+    override fun draw(canvas: Canvas) {
+        if (radius == 0f) return
+
+        canvas.drawCircle(centerX, centerY, radius, paint)
+    }
+
+    override fun setAlpha(alpha: Int) {
+        paint.alpha = alpha
+    }
+
+    override fun setColorFilter(colorFiter: ColorFilter?) {
+        paint.colorFilter = colorFilter
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+}

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModel.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModel.kt
@@ -23,6 +23,7 @@ import androidx.camera.extensions.ExtensionMode
 import androidx.camera.extensions.ExtensionsManager
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
+import androidx.compose.ui.layout.ScaleFactor
 import androidx.core.net.toUri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
@@ -264,6 +265,12 @@ class CameraExtensionsViewModel(
 
         val meteringAction = FocusMeteringAction.Builder(meteringPoint).build()
         camera.cameraControl.startFocusAndMetering(meteringAction)
+    }
+
+    fun scale(scaleFactor: Float) {
+        val camera = camera ?: return
+        val currentZoomRatio: Float = camera.cameraInfo.zoomState.value?.zoomRatio ?: 1f
+        camera.cameraControl.setZoomRatio(scaleFactor * currentZoomRatio)
     }
 
     private fun cameraLensToSelector(@LensFacing lensFacing: Int): CameraSelector =

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModel.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModel.kt
@@ -55,6 +55,8 @@ class CameraExtensionsViewModel(
     private lateinit var cameraProvider: ProcessCameraProvider
     private lateinit var extensionsManager: ExtensionsManager
 
+    private var camera: Camera? = null
+
     private val imageCapture = ImageCapture.Builder()
         .setTargetAspectRatio(AspectRatio.RATIO_16_9)
         .build()
@@ -145,7 +147,7 @@ class CameraExtensionsViewModel(
             .addUseCase(preview)
             .build()
         cameraProvider.unbindAll()
-        cameraProvider.bindToLifecycle(
+        camera = cameraProvider.bindToLifecycle(
             lifecycleOwner,
             cameraSelector,
             useCaseGroup
@@ -255,6 +257,13 @@ class CameraExtensionsViewModel(
             )
             _captureUiState.emit(CaptureState.CaptureNotReady)
         }
+    }
+
+    fun focus(meteringPoint: MeteringPoint) {
+        val camera = camera ?: return
+
+        val meteringAction = FocusMeteringAction.Builder(meteringPoint).build()
+        camera.cameraControl.startFocusAndMetering(meteringAction)
     }
 
     private fun cameraLensToSelector(@LensFacing lensFacing: Int): CameraSelector =

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModelFactory.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewmodel/CameraExtensionsViewModelFactory.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.android.cameraxextensions.repository.ImageCaptureRepository
+
+/**
+ * Creates ViewModel instances of [CameraExtensionsViewModel] to support injection of [Application]
+ * and [ImageCaptureRepository]
+ */
+class CameraExtensionsViewModelFactory(
+    private val application: Application,
+    private val imageCaptureRepository: ImageCaptureRepository
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return CameraExtensionsViewModel(application, imageCaptureRepository) as T
+    }
+}

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CameraPreviewScreenViewState.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CameraPreviewScreenViewState.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.viewstate
+
+import com.example.android.cameraxextensions.adapter.CameraExtensionItem
+
+/**
+ * Represents the camera preview screen view state. The camera preview screen shows camera controls
+ * and the camera preview.
+ */
+data class CameraPreviewScreenViewState(
+    val shutterButtonViewState: ShutterButtonViewState = ShutterButtonViewState(),
+    val switchLensButtonViewState: SwitchLensButtonViewState = SwitchLensButtonViewState(),
+    val extensionsSelectorViewState: CameraExtensionSelectorViewState = CameraExtensionSelectorViewState()
+) {
+    fun hideCameraControls(): CameraPreviewScreenViewState =
+        copy(
+            shutterButtonViewState = shutterButtonViewState.copy(isVisible = false),
+            switchLensButtonViewState = switchLensButtonViewState.copy(isVisible = false),
+            extensionsSelectorViewState = extensionsSelectorViewState.copy(isVisible = false)
+        )
+
+    fun showCameraControls(): CameraPreviewScreenViewState =
+        copy(
+            shutterButtonViewState = shutterButtonViewState.copy(isVisible = true),
+            switchLensButtonViewState = switchLensButtonViewState.copy(isVisible = true),
+            extensionsSelectorViewState = extensionsSelectorViewState.copy(isVisible = true)
+        )
+
+    fun enableCameraShutter(isEnabled: Boolean): CameraPreviewScreenViewState =
+        copy(shutterButtonViewState = shutterButtonViewState.copy(isEnabled = isEnabled))
+
+    fun enableSwitchLens(isEnabled: Boolean): CameraPreviewScreenViewState =
+        copy(switchLensButtonViewState = switchLensButtonViewState.copy(isEnabled = isEnabled))
+
+    fun setAvailableExtensions(extensions: List<CameraExtensionItem>): CameraPreviewScreenViewState =
+        copy(extensionsSelectorViewState = extensionsSelectorViewState.copy(extensions = extensions))
+}
+
+data class CameraExtensionSelectorViewState(
+    val isVisible: Boolean = false,
+    val extensions: List<CameraExtensionItem> = emptyList()
+)
+
+data class ShutterButtonViewState(
+    val isVisible: Boolean = false,
+    val isEnabled: Boolean = false
+)
+
+data class SwitchLensButtonViewState(
+    val isVisible: Boolean = false,
+    val isEnabled: Boolean = false
+)

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CaptureScreenViewState.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CaptureScreenViewState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.viewstate
+
+/**
+ * Capture Screen is the top level view state. A capture screen contains a camera preview screen
+ * and a post capture screen.
+ */
+data class CaptureScreenViewState(
+    val cameraPreviewScreenViewState: CameraPreviewScreenViewState = CameraPreviewScreenViewState(),
+    val postCaptureScreenViewState: PostCaptureScreenViewState = PostCaptureScreenViewState.PostCaptureScreenHiddenViewState
+) {
+    fun updateCameraScreen(block: (cameraPreviewScreenViewState: CameraPreviewScreenViewState) -> CameraPreviewScreenViewState): CaptureScreenViewState =
+        copy(cameraPreviewScreenViewState = block(cameraPreviewScreenViewState))
+
+    fun updatePostCaptureScreen(block: (postCaptureScreenViewState: PostCaptureScreenViewState) -> PostCaptureScreenViewState) =
+        copy(postCaptureScreenViewState = block(postCaptureScreenViewState))
+}

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/PostCaptureScreenViewState.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/PostCaptureScreenViewState.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.cameraxextensions.viewstate
+
+import android.net.Uri
+
+/**
+ * Represents the post capture screen view state. This can be either visible with a uri for the
+ * photo captured or hidden.
+ */
+sealed interface PostCaptureScreenViewState {
+    object PostCaptureScreenHiddenViewState : PostCaptureScreenViewState
+
+    data class PostCaptureScreenVisibleViewState(val uri: Uri) : PostCaptureScreenViewState
+}

--- a/CameraXExtensions/app/src/main/res/layout/activity_main.xml
+++ b/CameraXExtensions/app/src/main/res/layout/activity_main.xml
@@ -32,6 +32,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/focusPoint"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/extensionSelector"
         android:layout_width="0dp"

--- a/CameraXExtensions/app/src/main/res/xml/file_paths.xml
+++ b/CameraXExtensions/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-media-path name="media" path="." />
+    <files-path name="files" path="."/>
+</paths>

--- a/CameraXExtensions/build.gradle
+++ b/CameraXExtensions/build.gradle
@@ -17,10 +17,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     ext.java_version = JavaVersion.VERSION_11
 
-    ext.camerax_version = '1.1.0-beta01'
+    ext.camerax_version = '1.2.0-beta02'
     ext.coroutines_version = '1.6.0'
     ext.lifecycle_version = '2.5.1'
     ext.camerax = '1.2.0-alpha04'
@@ -30,8 +30,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
1. Refactor to add view state models for capture screen, camera preview, and post capture -- this is to help prepare for a simpler integration with Compose
2. Publish the photo so it can be picked up by the Gallery and other apps
3. Allow intercepting the back press when the photo capture screen is visible so using the back button behaves the same as the "x" button
4. Support tap to focus and double tap to switch camera
5. Tap to focus shows and animates a focus point
6. Support zoom in/out via pinch to zoom gesture