### PR TITLE
Bump dependencies for Camera2Basic, update Gradle

### DIFF
--- a/Camera2Basic/app/build.gradle
+++ b/Camera2Basic/app/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "androidx.navigation.safeargs"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        applicationId "com.android.example.camera2.basic"
+        applicationId "com.example.android.camera2.basic"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
     }
@@ -49,44 +49,45 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.example.android.camera2.basic'
 }
 
 dependencies {
     implementation project(':utils')
 
     // Kotlin lang
-    implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
 
     // App compat and UI things
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation "androidx.viewpager2:viewpager2:1.0.0"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // Navigation library
-    def nav_version = '2.2.2'
+    def nav_version = '2.5.3'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     // EXIF Interface
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.5'
 
     // Glide
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
     kapt 'com.github.bumptech.glide:compiler:4.11.0'
 
     // Unit testing
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'androidx.test.ext:junit:1.1.4'
+    testImplementation 'androidx.test:rules:1.5.0'
+    testImplementation 'androidx.test:runner:1.5.1'
+    testImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    testImplementation 'org.robolectric:robolectric:4.4'
 
     // Instrumented testing
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/Camera2Basic/app/src/main/AndroidManifest.xml
+++ b/Camera2Basic/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
   ~ limitations under the License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.android.camera2.basic">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Permission declarations -->
     <uses-permission android:name="android.permission.CAMERA" />
@@ -27,7 +26,6 @@
 
     <application
         android:allowBackup="true"
-        android:fullBackupContent="true"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
         tools:ignore="GoogleAppIndexingWarning">
@@ -35,7 +33,8 @@
         <activity
             android:name="com.example.android.camera2.basic.CameraActivity"
             android:clearTaskOnLaunch="true"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+            android:exported="true">
 
             <!-- Main app intent filter -->
             <intent-filter>

--- a/Camera2Basic/build.gradle
+++ b/Camera2Basic/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.7.20'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {
@@ -26,9 +26,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
+++ b/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Mar 31 20:44:51 PDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/Camera2Basic/utils/build.gradle
+++ b/Camera2Basic/utils/build.gradle
@@ -18,13 +18,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -45,31 +43,32 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.example.android.camera.utils'
 }
 
 dependencies {
 
     // Kotlin lang
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
 
     // App compat and UI things
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     // EXIF Interface
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.5'
 
     // Unit testing
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'androidx.test.ext:junit:1.1.4'
+    testImplementation 'androidx.test:rules:1.5.0'
+    testImplementation 'androidx.test:runner:1.5.1'
+    testImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    testImplementation 'org.robolectric:robolectric:4.4'
 
     // Instrumented testing
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/Camera2Basic/utils/src/main/AndroidManifest.xml
+++ b/Camera2Basic/utils/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest package="com.example.android.camera.utils" />
+<manifest />


### PR DESCRIPTION
Also fixes an `applicationId` typo, moves package ID from the manifests to namespaces in the `build.gradle` files, and tweaks a couple properties in the app manifest that have changed in more recent Android versions.