### PR TITLE
Camera2extensions add zoom and focus support

### DIFF
--- a/Camera2Extensions/app/build.gradle
+++ b/Camera2Extensions/app/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "androidx.navigation.safeargs"
 
 android {
-    compileSdkVersion 'android-31'
+    compileSdkVersion 'android-33'
     defaultConfig {
         testInstrumentationRunner kotlin_version
         applicationId "com.android.example.camera2.extensions"
         minSdkVersion 31
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
     }

--- a/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/ZoomUtil.kt
+++ b/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/ZoomUtil.kt
@@ -1,0 +1,41 @@
+package com.example.android.camera2.extensions
+
+import android.graphics.Rect
+import android.hardware.camera2.CameraCharacteristics
+
+object ZoomUtil {
+
+    fun minZoom() = 1.0f
+
+    fun maxZoom(characteristics: CameraCharacteristics): Float {
+        val maxZoom = characteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM)
+            ?: return minZoom()
+
+        if (maxZoom < minZoom()) return minZoom()
+
+        return maxZoom
+    }
+
+    fun getZoomCropRect(zoomRatio: Float, characteristics: CameraCharacteristics): Rect {
+        val sensorRect = sensorRect(characteristics)
+        return cropRectByRatio(zoomRatio, sensorRect)
+    }
+
+    private fun cropRectByRatio(zoomRatio: Float, sensorRect: Rect): Rect {
+        val cropWidth = sensorRect.width() / zoomRatio
+        val cropHeight = sensorRect.height() / zoomRatio
+
+        val left = (sensorRect.width() - cropWidth) / 2.0f
+        val top = (sensorRect.height() - cropHeight) / 2.0f
+
+        return Rect(
+            left.toInt(),
+            top.toInt(),
+            (left + cropWidth).toInt(),
+            (top + cropHeight).toInt()
+        )
+    }
+
+    private fun sensorRect(characteristics: CameraCharacteristics): Rect =
+        characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)!!
+}

--- a/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/ZoomUtil.kt
+++ b/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/ZoomUtil.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.android.camera2.extensions
 
 import android.graphics.Rect

--- a/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
+++ b/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
@@ -632,6 +632,9 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
       return false
     }
 
+    // Reset zoom -- TODO(Support zoom and tap to focus)
+    zoomRatio = ZoomUtil.minZoom()
+
     cameraExtensionSession.stopRepeating()
     cancelPendingAutoFocus()
     startAutoFocus(meteringRectangle(event))

--- a/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
+++ b/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
@@ -133,6 +133,10 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
   // setZoom on Camera.Parameters.
   private val scaleGestureListener = object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
     override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+      if (!hasZoomSupport()) {
+        return false
+      }
+
       // In case there is any focus happening, stop it.
       cancelPendingAutoFocus()
       return true
@@ -661,6 +665,21 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
 
     return false
   }
+
+  /**
+   * Not all camera extensions have zoom support.
+   * Returns true if zoom is supported otherwise false.
+   */
+  private fun hasZoomSupport(): Boolean {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      val availableExtensionRequestKeys =
+        extensionCharacteristics.getAvailableCaptureRequestKeys(currentExtension)
+      return availableExtensionRequestKeys.contains(CaptureRequest.CONTROL_ZOOM_RATIO)
+    }
+
+    return false
+  }
+
 
   /**
    * Translates a touch event relative to the preview surface to a region relative to the sensor.

--- a/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
+++ b/Camera2Extensions/app/src/main/java/com/example/android/camera2/extensions/fragments/CameraFragment.kt
@@ -675,7 +675,7 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
     val halfMeteringRectHeight = (METERING_RECTANGLE_SIZE * sensorSize.height()) / 2
 
     // Normalize the [x,y] touch point in the view port to values in the range of [0,1]
-    val normalizedPoint = floatArrayOf(event.x / previewSize.width, event.y / previewSize.height)
+    val normalizedPoint = floatArrayOf(event.x / previewSize.height, event.y / previewSize.width)
 
     // Scale and rotate the normalized point such that it maps to the sensor region
     Matrix().apply {
@@ -698,7 +698,7 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
     submitRequest(
       CameraDevice.TEMPLATE_PREVIEW,
       previewSurface,
-      true,
+      false,
     ) { request ->
       request.apply {
         set(CaptureRequest.CONTROL_AF_REGIONS, arrayOf(meteringRectangle))
@@ -714,7 +714,7 @@ class CameraFragment : Fragment(), TextureView.SurfaceTextureListener {
     submitRequest(
       CameraDevice.TEMPLATE_PREVIEW,
       previewSurface,
-      false
+      true
     ) { request ->
       request.apply {
         set(CaptureRequest.CONTROL_ZOOM_RATIO, zoomRatio)


### PR DESCRIPTION
Add tap to focus and zoom

 - a check to see if focus or zoom is supported is added since not all camera extensions support this capability
 - tap to focus does not account for the current zoom
  - zoom is supported via the pinch to zoom gesture