### PR TITLE
Request to change rootProject.name from "Camerax-MLKit" to "CameraX-MLKit"

### DIFF
--- a/CameraX-MLKit/settings.gradle
+++ b/CameraX-MLKit/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "Camerax-MLKit"
+rootProject.name = "CameraX-MLKit"
 include ':app'


### PR DESCRIPTION
I found a small error while trying to practice CameraX-MLKit.

The following error occurred because the rootProject.name in settings.gradle was set to Camerax-MLKit instead of CameraX-MLKit.

```
java.lang.IllegalStateException: Module entity with name: CameraX-MLKit should be available
```
To resolve this error, simply change rootProject.name to the same as the Root folder.

Please change rootProject.name to CameraX-MLKit.