### PR TITLE
Upgrade Gradle Plugin and dependency errors in Camera2Basic

### DIFF
--- a/Camera2Basic/app/build.gradle
+++ b/Camera2Basic/app/build.gradle
@@ -77,4 +77,17 @@ dependencies {
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     kapt 'com.github.bumptech.glide:compiler:4.11.0'
+
+    // Unit testing
+    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
+
+    // Instrumented testing
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/Camera2Basic/app/build.gradle
+++ b/Camera2Basic/app/build.gradle
@@ -20,12 +20,13 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "androidx.navigation.safeargs"
 
 android {
-    compileSdkVersion 29
+    namespace = "com.example.android.camera2.basic"
+    compileSdkVersion 34
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         applicationId "com.android.example.camera2.basic"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
     }
@@ -76,17 +77,4 @@ dependencies {
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     kapt 'com.github.bumptech.glide:compiler:4.11.0'
-
-    // Unit testing
-    testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
-
-    // Instrumented testing
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/Camera2Basic/app/src/main/AndroidManifest.xml
+++ b/Camera2Basic/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         <activity
             android:name="com.example.android.camera2.basic.CameraActivity"
             android:clearTaskOnLaunch="true"
+            android:exported="true"
             android:theme="@style/AppTheme">
 
             <!-- Main app intent filter -->

--- a/Camera2Basic/build.gradle
+++ b/Camera2Basic/build.gradle
@@ -26,9 +26,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
+++ b/Camera2Basic/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 31 20:44:51 PDT 2021
+#Wed Nov 13 11:56:06 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/Camera2Basic/utils/build.gradle
+++ b/Camera2Basic/utils/build.gradle
@@ -18,6 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "com.example.android.camera2.basic"
     compileSdkVersion 29
 
     defaultConfig {

--- a/Camera2Basic/utils/src/main/AndroidManifest.xml
+++ b/Camera2Basic/utils/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<manifest package="com.example.android.camera.utils" />
+<manifest />


### PR DESCRIPTION
When trying to build Camera2Basic in a more up-to-date version of Android Studio, I received errors for the version of gradle and the gradle plugin. Upgrading gradle caused some build errors as the namespace requirements had changed between versions. 

This patch updates those versions and fixes the namespaces in Camera2Basic so users can run the tutorial app on current versions of Android Studio.

All existing tests pass and the build successfully runs on my Google Pixel 9 Pro XL running Android 15. 
