### PR TITLE
Update the CameraX version 1.4.1 to ensure it works on Pixel 9 devices.

### DIFF
--- a/CameraXExtensions/build.gradle
+++ b/CameraXExtensions/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.kotlin_version = '1.9.22'
     ext.java_version = JavaVersion.VERSION_11
 
-    ext.camerax_version = '1.4.0-beta01'
+    ext.camerax_version = '1.4.1'
     ext.coroutines_version = '1.8.1'
     ext.lifecycle_version = '2.8.0'
 


### PR DESCRIPTION
CameraX version 1.4.1 fixed a critical issue on Pixel 9 series devices.