### PR TITLE
Add Capture Latency Estiamte Indicator for Extension

### DIFF
--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiState.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/model/CameraUiState.kt
@@ -20,6 +20,7 @@ import android.graphics.Bitmap
 import androidx.camera.core.CameraSelector.LENS_FACING_BACK
 import androidx.camera.core.CameraSelector.LensFacing
 import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureLatencyEstimate
 import androidx.camera.extensions.ExtensionMode
 
 /**
@@ -33,6 +34,8 @@ data class CameraUiState(
     val availableCameraLens: List<Int> = listOf(LENS_FACING_BACK),
     @LensFacing val cameraLens: Int = LENS_FACING_BACK,
     @ExtensionMode.Mode val extensionMode: Int = ExtensionMode.NONE,
+    val realtimeCaptureLatencyEstimate: ImageCaptureLatencyEstimate =
+        ImageCaptureLatencyEstimate.UNDEFINED_IMAGE_CAPTURE_LATENCY
 )
 
 /**
@@ -48,6 +51,12 @@ enum class CameraState {
      * Camera is open and presenting a preview stream.
      */
     READY,
+
+    /**
+     * Camera is open and preview stream is currently running.
+     * Updates during this period are from camera state operations.
+     */
+    PREVIEW_ACTIVE,
 
     /**
      * Camera is initialized but the preview has been stopped.

--- a/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CameraPreviewScreenViewState.kt
+++ b/CameraXExtensions/app/src/main/java/com/example/android/cameraxextensions/viewstate/CameraPreviewScreenViewState.kt
@@ -28,7 +28,8 @@ data class CameraPreviewScreenViewState(
     val switchLensButtonViewState: SwitchLensButtonViewState = SwitchLensButtonViewState(),
     val extensionsSelectorViewState: CameraExtensionSelectorViewState = CameraExtensionSelectorViewState(),
     val processProgressViewState: ProcessProgressIndicatorViewState = ProcessProgressIndicatorViewState(),
-    val postviewViewState: PostviewViewState = PostviewViewState()
+    val postviewViewState: PostviewViewState = PostviewViewState(),
+    val latencyEstimateIndicatorViewState: LatencyEstimateIndicatorViewState = LatencyEstimateIndicatorViewState()
 ) {
     fun hideCameraControls(): CameraPreviewScreenViewState =
         copy(
@@ -63,6 +64,22 @@ data class CameraPreviewScreenViewState(
 
     fun hideProcessProgressViewState(): CameraPreviewScreenViewState =
         copy(processProgressViewState = ProcessProgressIndicatorViewState())
+
+    fun showLatencyEstimateIndicator(latencyEstimateMillis: Long): CameraPreviewScreenViewState =
+        copy(
+            latencyEstimateIndicatorViewState = LatencyEstimateIndicatorViewState(
+                isVisible = true,
+                latencyEstimateMillis = latencyEstimateMillis
+            )
+        )
+
+    fun hideLatencyEstimateIndicator(): CameraPreviewScreenViewState =
+        copy(
+            latencyEstimateIndicatorViewState = LatencyEstimateIndicatorViewState(
+                isVisible = false,
+                latencyEstimateMillis = 0
+            )
+        )
 }
 
 data class CameraExtensionSelectorViewState(
@@ -88,4 +105,9 @@ data class ProcessProgressIndicatorViewState(
 data class PostviewViewState(
     val isVisible: Boolean = false,
     val bitmap: Bitmap? = null
+)
+
+data class LatencyEstimateIndicatorViewState(
+    val isVisible: Boolean = false,
+    val latencyEstimateMillis: Long = 0
 )

--- a/CameraXExtensions/app/src/main/res/layout/activity_main.xml
+++ b/CameraXExtensions/app/src/main/res/layout/activity_main.xml
@@ -20,13 +20,13 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:background="#2196F3"
     tools:context=".MainActivity">
 
     <androidx.camera.view.PreviewView
         android:id="@+id/previewView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        tools:background="#2196F3"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -144,6 +144,22 @@
             app:trackCornerRadius="3dp" />
     </LinearLayout>
 
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/latencyEstimateIndicator"
+        android:layout_width="38dp"
+        android:layout_height="38dp"
+        android:paddingBottom="2dp"
+        android:gravity="center"
+        android:textColor="#FFBE0B"
+        android:textSize="12sp"
+        android:background="@drawable/circle_background"
+        android:layout_margin="32dp"
+        app:layout_constraintBottom_toBottomOf="@id/cameraShutter"
+        app:layout_constraintStart_toEndOf="@id/cameraShutter"
+        app:layout_constraintTop_toTopOf="@id/cameraShutter"
+        tools:text="9s"
+        />
+
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/permissionsRationaleContainer"
         android:layout_width="0dp"
@@ -155,7 +171,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="gone" >
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/permissionsRationale"

--- a/CameraXExtensions/app/src/main/res/values/strings.xml
+++ b/CameraXExtensions/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="camera_permissions_action">Turn On</string>
 
     <string name="hold_still">Hold Still</string>
+    <string name="latency_estimate">%ds</string>
 </resources>

--- a/CameraXExtensions/build.gradle
+++ b/CameraXExtensions/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
- camera extension can query for the realtime capture latency estimate
- display this as a hint to the user how long to hold still for