### PR TITLE
upgrade Camera2Basic's kotlin to 2.1.10

### DIFF
--- a/Camera2Basic/build.gradle
+++ b/Camera2Basic/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     // Top-level variables used for versioning
-    ext.kotlin_version = '1.9.20'
+    ext.kotlin_version = '2.1.10'
     ext.java_version = JavaVersion.VERSION_1_8
 
     repositories {


### PR DESCRIPTION
kotlin 1.9.20 produces `java.lang.IllegalAccessError: superclass access check failed: class org.jetbrains.kotlin.kapt3.base.javac.KaptJavaCompiler (in unnamed module @0x404ab5a2) cannot access class com.sun.tools.javac.main.JavaCompiler (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.main to unnamed module @0x404ab5a2`
