### PR TITLE
Fix flash overlay animation not appearing fully over SurfaceView by using a dedicated overlay View

### DIFF
--- a/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/CameraFragment.kt
+++ b/CameraXBasic/app/src/main/java/com/android/example/cameraxbasic/fragments/CameraFragment.kt
@@ -19,8 +19,6 @@ package com.android.example.cameraxbasic.fragments
 import android.annotation.SuppressLint
 import android.content.*
 import android.content.res.Configuration
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.hardware.display.DisplayManager
 import android.os.Build
 import android.os.Bundle
@@ -51,6 +49,7 @@ import com.android.example.cameraxbasic.utils.MediaStoreUtils
 import com.android.example.cameraxbasic.utils.simulateClick
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
@@ -517,15 +516,17 @@ class CameraFragment : Fragment() {
                     }
                 })
 
-                // We can only change the foreground Drawable using API level 23+ API
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-
-                    // Display flash animation to indicate that photo was captured
-                    fragmentCameraBinding.root.postDelayed({
-                        fragmentCameraBinding.root.foreground = ColorDrawable(Color.WHITE)
-                        fragmentCameraBinding.root.postDelayed(
-                                { fragmentCameraBinding.root.foreground = null }, ANIMATION_FAST_MILLIS)
-                    }, ANIMATION_SLOW_MILLIS)
+                // Display flash animation to indicate that photo was captured
+                viewLifecycleOwner.lifecycleScope.launch {
+                    delay(ANIMATION_SLOW_MILLIS)
+                    fragmentCameraBinding.whiteOverlay.apply {
+                        alpha = 1f
+                        visibility = View.VISIBLE
+                        animate()
+                            .alpha(0f)
+                            .setDuration(ANIMATION_FAST_MILLIS)
+                            .withEndAction { visibility = View.GONE }
+                    }
                 }
             }
         }

--- a/CameraXBasic/app/src/main/res/layout/fragment_camera.xml
+++ b/CameraXBasic/app/src/main/res/layout/fragment_camera.xml
@@ -26,4 +26,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <View
+        android:id="@+id/white_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/white"
+        android:alpha="0"
+        android:visibility="gone"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The foreground drawable was not rendering fully over the entire screen due to the use of `SurfaceView` by `PreviewView` when `ImplementationMode.PERFORMANCE` is used (which is the default)([Source](https://developer.android.com/reference/androidx/camera/view/PreviewView.ImplementationMode#PERFORMANCE)). `SurfaceView` draws in a separate window layer, which causes it to clip or obscure any views (like overlays or foregrounds) placed above it in the view hierarchy.

Instead of switching to `TextureView` via `ImplementationMode.COMPATIBLE` (which is less performant [[source]](https://developer.android.com/reference/androidx/camera/view/PreviewView.ImplementationMode)), this fix introduces a dedicated full-screen overlay View positioned above the camera preview. The flash animation is now handled by toggling the visibility and animating the alpha of this overlay view, ensuring consistent visual feedback without compromising performance.

Additionally, this approach eliminates the need for API-level checks (previously required for Android 23 and below), making the flash animation available across all supported versions.


| Description | Link |
|-------------|------|
| Before      | https://github.com/user-attachments/assets/4b14eec4-4dc9-4a20-923e-c338df137f5a |
| After       | https://github.com/user-attachments/assets/5368dca5-a35b-454e-a4b1-7c504eb1401b |





